### PR TITLE
Fix docstring to mention run_command

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ class MemoryDumpAnalyzerApp(tk.Tk):
     Methods:
     - __init__: Initializes the MemoryDumpAnalyzerApp class and sets up the GUI layout.
     - createWidgets: Creates all the necessary widgets for the GUI.
+    - run_command: Executes a WinDbg command entered in the GUI.
     - browse_file: Opens a file dialog for browsing memory dump files.
     - get_symbol_path: Generates the symbol path based on selected parameters.
     - analyze: Analyzes the memory dump using specified parameters and displays the output.


### PR DESCRIPTION
## Summary
- document the `run_command` method in `MemoryDumpAnalyzerApp`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_b_687e984c387c832cbf47a6919736d316